### PR TITLE
いいなりに従って出力のバグを修正

### DIFF
--- a/lib/iinari.rb
+++ b/lib/iinari.rb
@@ -7,12 +7,14 @@ module Iinari
     files = Dir.entries(draft_dir).select{|name| name =~ /^1[0-9]/}.sort.collect{|p| File.join(draft_dir, p)}
 
     files.each do |file_name|
+      @chapter = false
       doc = Docx::Document.open(file_name)
       sections = doc.paragraphs.map {|p| p.text}.select{|p| p =~ /^第[0-9]章|^[0-9]\.[0-9][\s\.]/}
 
       sections.each do |s|
-        if s =~ /^第[0-9]章/
+        if s =~ /^第[0-9]章/ && ! @chapter
           puts '■ ' + s.gsub(/第|章/, '第' => '', '章' => ' ')
+          @chapter = true
         elsif s =~ /^[0-9]\.[0-9]\s/
           puts "★ #{s} "
         elsif s =~ /^[0-9]\.[0-9]\./


### PR DESCRIPTION
章の文章中の行頭に「第N章」が入っていた場合、章情報の行として解釈されるバグを修正しました。